### PR TITLE
Fix bug in the URL when search something in the product page and click enter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix bug in the url when search something in the product page and click enter.
 
 ## [1.1.0] - 2018-05-21
 ### Changed

--- a/react/components/SearchBar/index.js
+++ b/react/components/SearchBar/index.js
@@ -15,7 +15,7 @@ export default class SearchBar extends Component {
   // frameworks, like React Router or another approach.
   handleEnterPress(event) {
     if (event.key === 'Enter') {
-      window.location = `${event.target.value}/s`
+      location.assign(`/${event.target.value}/s`)
     }
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix bug in the URL when search something in the product page and click enter.

#### What problem is this solving?
![captura de tela de 2018-05-22 14-48-22](https://user-images.githubusercontent.com/12852518/40380336-34156418-5dcf-11e8-90cf-f359f34ec1e4.png)

#### How should this be manually tested?
![Access the workspace](https://fixsearchbar--storecomponents.myvtex.com/)

#### Screenshots or example usage

#### Types of changes
- [Z] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
